### PR TITLE
ci: update workflow

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -5,22 +5,31 @@ on:
   workflow_dispatch:
 jobs:
   refresh:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v16
+    - uses: actions/checkout@v6
+    - name: Install Tor
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y tor
+        sudo service tor start
+        sleep 10  # Give Tor some time to bootstrap
+    - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-24.11
+        nix_path: nixpkgs=channel:nixos-25.11
     - run: nix run .#generate
+      env:
+        https_proxy: socks5://localhost:9050
     - name: Count laws
       id: count_laws
       run: |
         count=$(find laws -type f | wc -l)
         echo "Found $count laws"
         echo "count=$count" >> $GITHUB_OUTPUT
-    - uses: EndBug/add-and-commit@v7
+    - uses: EndBug/add-and-commit@v10
       if: steps.count_laws.outputs.count >= 100
       with:
         default_author: github_actions
         message: refresh laws
-        branch: master


### PR DESCRIPTION

The workflow often timed out. 

Ref: https://github.com/kmein/gesetze/issues/7#issuecomment-4310907928

After contacting **info[at]juris.de** and **kompetenzzentrum-ris[at]bfj.bund.de**,
they confirmed the following:

**BfJ.Bund.de:** _unser technischer Dienstleister, der das Angebot "Gesetze im_
_Internet" betreibt, war aufgrund von Sicherheitsmaßnahmen zuletzt gezwungen,_
_einen größeren IP-Bereich für Zugriffe zu sperren. Wie lange das Problem_
_andauern wird, kann ich leider nicht sagen._

The workflow likely succeeded sometimes when GitHub used an IP not blocked by
`gesetze-im-internet`.

A full list of GitHub Action IPs are listed here: https://api.github.com/meta

---

The idea of this PR is to use Tor to bypass the blocking of GitHub Actions
runners’ IP addresses.

The Actions workflows were also updated to address the Node 20 deprecation
warnings. Additionally, the `branch` input field for `EndBug/add-and-commit@v10`
has been deprecated and was removed.

---

It’s up to you whether this proposed change is worth trying. It may cause
`gesetze-im-internet` to start blocking `Tor` as well.

**EDIT:** link to issue discussion about timed out workflow